### PR TITLE
[Fix] 메인 뷰 마크업 수정

### DIFF
--- a/src/components/idea/IdeaSection.css
+++ b/src/components/idea/IdeaSection.css
@@ -115,6 +115,11 @@
     display: inline-block;
 }
 
+.search-circle > img {
+    vertical-align: top;
+    margin-top: 13px;
+}
+
 .search-input {
     width: 270px;
     height: 100%;
@@ -211,6 +216,8 @@ span {
     height: 16px;
     object-fit: contain;
     margin-left: 6px;
+    vertical-align: top;
+    margin-top: 6px;
 }
 
 .Group-10 {
@@ -219,6 +226,8 @@ span {
     object-fit: contain;
     margin-left: 6px;
     cursor:pointer;
+    vertical-align: top;
+    margin-top: 6px;
 }
 
 .favorite {

--- a/src/components/idea/admin/AdminIdeaListSection.vue
+++ b/src/components/idea/admin/AdminIdeaListSection.vue
@@ -271,6 +271,11 @@
         display: inline-block;
     }
 
+    .search-circle > img {
+      vertical-align: top;
+      margin-top: 13px;
+    }
+
     .search-input {
         width: 270px;
         height: 100%;
@@ -372,5 +377,7 @@
         height: 16px;
         object-fit: contain;
         margin-left: 6px;
+        vertical-align: top;
+        margin-top: 6px;
     }
 </style>


### PR DESCRIPTION
메인 화면의 마크업이 깨지는 부분을 조금 수정해봤어요 :)

- 어드민
    - 아이디어 검색 창 이미지(돋보기) 수직 가운데 정렬   
    - 아이디어 선정 여부 정렬 버튼 수평 맞춤
- 유저
    - 아이디어 검색 창 이미지(돋보기) 수직 가운데 정렬
    - 태그의 호버 이미지(느낌표 이미지), 날짜 정렬 버튼 수평 맞춤 

(추가로, 로컬에서 테스트가 되지 않는 관계로 배포 후 확인은 필요하지만, 예상되는 문제는 없습니당..!)